### PR TITLE
Added support for command-only rules

### DIFF
--- a/example/helloworld/Marefile
+++ b/example/helloworld/Marefile
@@ -1,3 +1,4 @@
+whom = "world"
 
 linkFlags += {
   if tool == "vcxproj" { "/SUBSYSTEM:CONSOLE" }
@@ -8,5 +9,8 @@ targets = {
     files = {
       "*.cpp" = cppSource
     }
+  }
+  command_test = {
+    command = "echo Hello, $(whom)!"
   }
 }

--- a/src/mare/Mare.cpp
+++ b/src/mare/Mare.cpp
@@ -257,6 +257,13 @@ public:
     }
 
     // determine whether to build this rule
+    
+    // Command-only rules
+    if (outputs.isEmpty() && inputs.isEmpty() && !(command.isEmpty()))
+    {
+	  goto run;
+	}
+    
     for(Map<Rule*, String>::Node* i = ruleDependencies.getFirst(); i; i = i->getNext())
       if(i->key->rebuild)
       {
@@ -364,6 +371,8 @@ clean:
     // create output directories
     for(const List<String>::Node* i = outputs.getFirst(); i; i = i->getNext())
       Directory::create(File::getDirname(i->data));
+    
+    run:
 
     nextCommand = command.getFirst();
     return continueExecution(pid);


### PR DESCRIPTION
I modified Rule::startExecution to go straight to executing the command if the target has no input or output files (as requested in the issue I raised). I also put a test 'command_test' target into example/helloworld/Marefile just so you see how it works, but feel free to remove it.

When testing my changes, I found that command-only targets don't get transferred when translating to other build systems, however it works fine with Mare which is all I needed.
Otherwise my changes don't modify any existing Mare code.