### PR TITLE
Added support for VS2019

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -47,6 +47,13 @@ goto end
 :find_visual_studio
 if not "%VCINSTALLDIR%"=="" goto find_visual_studio_return
 
+FOR /F "usebackq tokens=*" %%A IN (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) DO (
+  if exist "%%A" (
+    call "%%A\VC\Auxiliary\Build\vcvars32.bat"
+    goto find_visual_studio_return
+  )
+)
+
 FOR /F "usebackq skip=2 tokens=2*" %%A IN (`reg query HKLM\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7 /v 15.0 2^>nul`) DO (
   if exist "%%B" (
     call "%%B\VC\Auxiliary\Build\vcvars32.bat"
@@ -92,7 +99,7 @@ set DEL_FILE=%MARE_OUTPUT_DIR:"=%/mare.exe
 del %DEL_FILE:/=\% 2>NUL
 endlocal
 for %%f in (%MARE_SOURCE_FILES%) do (
-  cl /I"%MARE_SOURCE_DIR:"=%/libmare" /Zi /nologo /W3 /WX- /Od /Oy- /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /Gm /EHsc /RTC1 /GS /fp:precise /Zc:wchar_t /Zc:forScope /Fd"%MARE_BUILD_DIR:"=%/" /Fo"%MARE_BUILD_DIR:"=%/" /Gd /analyze- /c "%MARE_SOURCE_DIR:"=%/%%f"
+  cl /I"%MARE_SOURCE_DIR:"=%/libmare" /Zi /nologo /W3 /WX- /Od /Oy- /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /EHsc /RTC1 /GS /fp:precise /Zc:wchar_t /Zc:forScope /Fd"%MARE_BUILD_DIR:"=%/" /Fo"%MARE_BUILD_DIR:"=%/" /Gd /analyze- /c "%MARE_SOURCE_DIR:"=%/%%f"
 )
 set MARE_OBJECTS=
 for %%f in (%MARE_BUILD_DIR:"=%/*.obj) do (

--- a/src/mare/Main.cpp
+++ b/src/mare/Main.cpp
@@ -68,7 +68,7 @@ static void showUsage(const char* executable)
   puts("");
   puts("    --vcxproj[=<version>]");
   puts("        Convert the marefile into a .sln and .vcxproj files for Visual Studio.");
-  puts("        <version> can be set to 2010, 2012, 2013, 2015 or 2017.");
+  puts("        <version> can be set to 2010, 2012, 2013, 2015, 2017 or 2019.");
   puts("");
   puts("    --vcproj[=<version>]");
   puts("        Convert the marefile into a .sln and .vcproj files for Visual Studio.");
@@ -258,6 +258,8 @@ int main(int argc, char* argv[])
                 generateVcxproj = 2015;
               else if(strcmp(optarg, "2017") == 0)
                 generateVcxproj = 2017;
+              else if(strcmp(optarg, "2019") == 0)
+                generateVcxproj = 2019;
               else // unknown version
                 ::showHelp(argv[0]);
             }

--- a/src/mare/Vcxproj.cpp
+++ b/src/mare/Vcxproj.cpp
@@ -902,7 +902,9 @@ bool Vcxproj::generateSln()
   else
     fileWrite("Microsoft Visual Studio Solution File, Format Version 11.00\r\n");
 
-  if(version == 2017)
+  if(version == 2019)
+    fileWrite("# Visual Studio Version 16\r\n");
+  else if(version == 2017)
     fileWrite("# Visual Studio 15\r\n");
   else if(version == 2015)
     fileWrite("# Visual Studio 14\r\n");
@@ -1009,7 +1011,9 @@ bool Vcxproj::generateVcxproj(Project& project)
   fileOpen(project.projectFile);
 
   fileWrite("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n");
-  if(version == 2017)
+  if(version == 2019)
+    fileWrite("<Project DefaultTargets=\"Build\" ToolsVersion=\"16.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\r\n");
+  else if(version == 2017)
     fileWrite("<Project DefaultTargets=\"Build\" ToolsVersion=\"15.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\r\n");
   else if(version == 2015)
     fileWrite("<Project DefaultTargets=\"Build\" ToolsVersion=\"14.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\r\n");
@@ -1056,6 +1060,8 @@ bool Vcxproj::generateVcxproj(Project& project)
       fileWrite("    <UseDebugLibraries>false</UseDebugLibraries>\r\n");
     if(config.vsOptions.find("PlatformToolset"))
       fileWrite(String("    <PlatformToolset>") + config.vsOptions.lookup("PlatformToolset") + "</PlatformToolset>\r\n");
+    else if(version == 2019)
+      fileWrite("    <PlatformToolset>v142</PlatformToolset>\r\n");
     else if(version == 2017)
       fileWrite("    <PlatformToolset>v141</PlatformToolset>\r\n");
     else if(version == 2015)


### PR DESCRIPTION
The new version neither sets a environment variable nor a registry key with the path of the installation.
However, vswhere is now packaged with the Visual Studio installation--and according to [their documentation](https://github.com/Microsoft/vswhere), its path is fixed.

The option `/Gm` is deprecated, so I removed it from the compile script. However, Vcxproj.cpp still supports it.